### PR TITLE
update software url valid regex

### DIFF
--- a/js/screens/SetupInstallCustom/SetupInstallCustom.js
+++ b/js/screens/SetupInstallCustom/SetupInstallCustom.js
@@ -44,7 +44,7 @@ class SetupInstallCustom extends Component {
     }
 
     hasValidURL(softwareUrl) {
-        const expression = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;
+        const expression = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,18}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;
         var pattern = new RegExp(expression);
         return pattern.test(softwareUrl);
     }


### PR DESCRIPTION
The software domain maybe has a long suffix than 6.

eg. https://openpilot.download/op/release2

If custom installer is allowed, I want to modify this validation rule to allow the use of domain names like openpilot.download

thx.